### PR TITLE
Add weather API and booking trend visualizations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,6 @@ requests>=2.31.0
 # urllib3 will be installed automatically with compatible version
 
 schedule==1.2.0
+pandas>=2.0.0
+numpy>=1.24.0
+matplotlib>=3.8.0


### PR DESCRIPTION
## Summary
- Switch weather integration to API-key-free Open-Meteo and decode weather codes for demand adjustments
- Add 7- and 30-day overlays with matplotlib to visualize 90-day booking trends
- Document revenue calculation assumptions and include plotting dependencies

## Testing
- `python -m py_compile enhanced_4spa_analytics.py`
- `python enhanced_4spa_analytics.py` *(fails: No such file or directory: 'onsen-scraping-e41c80c00b93.json')*


------
https://chatgpt.com/codex/tasks/task_e_6890ecb023dc8327ad697d9b421ae619