### PR TITLE
Use range-based sheet clearing to keep formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ The scraper populates these tabs:
 - **SameDay_Mirror**, etc.: Conservative estimates
 - **📈 Historical Data (9-Spa Model)**: All data over time
 
+### Sheet Updates on Rerun
+
+Each execution clears only the data rows (starting at row 2) while keeping the
+header row and any existing formatting intact. If a full reset of a worksheet is
+ever needed, run the clear manually and then reapply formatting using the helper
+in `sheets_writer.py`.
+
 ## 🛠️ Troubleshooting
 
 1. **No data appearing**: Check `fallback_logs/` for screenshots


### PR DESCRIPTION
## Summary
- replace full worksheet clearing with range-based clear to keep header row and styling
- add helper to reapply header formatting after data overwrite
- document rerun behavior in README

## Testing
- `python -m py_compile sheets_writer.py`


------
https://chatgpt.com/codex/tasks/task_e_68910321f6708327acbe29cf6a26f1f6