### PR TITLE
Add header row management for sheet appends

### DIFF
--- a/onsen_scraper_v4.py
+++ b/onsen_scraper_v4.py
@@ -540,22 +540,28 @@ def run_scraper(headless=True, test_mode=False):
         if all_historical_data:
             try:
                 print(f"\n📈 Appending {len(all_historical_data)} records to Historical Data tab...", flush=True)
-                
-                # Check if we need headers (first time)
-                from sheets_writer import check_if_sheet_exists
+
                 historical_tab = "📈 Historical Data (9-Spa Model)"
-                
-                if not check_if_sheet_exists(SHEET_ID, historical_tab):
-                    # First time - write with headers
-                    headers = [["Scrape Timestamp", "Booking Date", "Time Slot", "Slots Available", "Slots Booked", "Revenue", "Horizon"]]
-                    headers.extend(all_historical_data)
-                    write_to_sheets(SHEET_ID, historical_tab, headers)
-                    print(f"✅ Created Historical Data tab with {len(all_historical_data)} records", flush=True)
-                else:
-                    # Append to existing data
-                    append_to_sheets(SHEET_ID, historical_tab, all_historical_data)
-                    print(f"✅ Appended {len(all_historical_data)} records to Historical Data", flush=True)
-                    
+                historical_headers = [
+                    "Scrape Timestamp",
+                    "Booking Date",
+                    "Time Slot",
+                    "Slots Available",
+                    "Slots Booked",
+                    "Revenue",
+                    "Horizon",
+                ]
+                append_to_sheets(
+                    SHEET_ID,
+                    historical_tab,
+                    all_historical_data,
+                    headers=historical_headers,
+                )
+                print(
+                    f"✅ Appended {len(all_historical_data)} records to Historical Data",
+                    flush=True,
+                )
+
             except Exception as e:
                 print(f"⚠️ Historical data append error: {e}", flush=True)
         

--- a/onsen_scraper_v4_FIXED.py
+++ b/onsen_scraper_v4_FIXED.py
@@ -540,22 +540,28 @@ def run_scraper(headless=True, test_mode=False):
         if all_historical_data:
             try:
                 print(f"\n📈 Appending {len(all_historical_data)} records to Historical Data tab...", flush=True)
-                
-                # Check if we need headers (first time)
-                from sheets_writer import check_if_sheet_exists
+
                 historical_tab = "📈 Historical Data (9-Spa Model)"
-                
-                if not check_if_sheet_exists(SHEET_ID, historical_tab):
-                    # First time - write with headers
-                    headers = [["Scrape Timestamp", "Booking Date", "Time Slot", "Slots Available", "Slots Booked", "Revenue", "Horizon"]]
-                    headers.extend(all_historical_data)
-                    write_to_sheets(SHEET_ID, historical_tab, headers)
-                    print(f"✅ Created Historical Data tab with {len(all_historical_data)} records", flush=True)
-                else:
-                    # Append to existing data
-                    append_to_sheets(SHEET_ID, historical_tab, all_historical_data)
-                    print(f"✅ Appended {len(all_historical_data)} records to Historical Data", flush=True)
-                    
+                historical_headers = [
+                    "Scrape Timestamp",
+                    "Booking Date",
+                    "Time Slot",
+                    "Slots Available",
+                    "Slots Booked",
+                    "Revenue",
+                    "Horizon",
+                ]
+                append_to_sheets(
+                    SHEET_ID,
+                    historical_tab,
+                    all_historical_data,
+                    headers=historical_headers,
+                )
+                print(
+                    f"✅ Appended {len(all_historical_data)} records to Historical Data",
+                    flush=True,
+                )
+
             except Exception as e:
                 print(f"⚠️ Historical data append error: {e}", flush=True)
         


### PR DESCRIPTION
## Summary
- define reusable HEADER_ROW default column names in sheets writer
- extend append_to_sheets to create new worksheet with headers and formatting
- update scraper scripts to supply explicit headers when appending historical data

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689109d0fcc483278c2ab3265ff8ee47